### PR TITLE
fixed namespaces issue with composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	},
 	"autoload" : {
 		"psr-0" : {
-			"Paradox" : "Paradox/"
+			"Paradox" : "."
 		}
 	},
 	"support" : {


### PR DESCRIPTION
Hi Francis,

I started to play around with Paradox using composer. The require section looks like this:

```
"require": {
    "triagens/arangodb": "dev-devel",
     "f21/paradox": "dev-master"
 }
```

Problem: The Paradox classes are not found through the autoloader generated by composer.
Reason: composer generates a file vendor/composer/autoload_namespaces.php. This points to the wrong path, in the old version it was 
    'Paradox' => array($vendorDir . '/f21/paradox/Paradox'),

I adapted the composer.json so it's now

```
'Paradox' => array($vendorDir . '/f21/paradox'),
```
